### PR TITLE
Initialize OriEx Flask + React scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Python
+__pycache__/
+*.pyc
+
+# Virtual environments
+env/
+venv/
+
+# Node
+node_modules/
+
+# Build
+frontend/build/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# OriEx-WebApp
+# OriEx
+
+Web application for managing shipping services from China to Argentina.
+
+## Stack
+- **Backend**: Python with Flask
+- **Frontend**: React
+- **Database**: PostgreSQL
+
+This repository contains a basic project structure with a Flask backend and a React frontend.
+

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,10 @@
+from flask import Flask
+
+def create_app():
+    app = Flask(__name__)
+    app.config.from_object('config.Config')
+
+    from . import routes
+    app.register_blueprint(routes.bp)
+
+    return app

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -1,0 +1,7 @@
+from flask import Blueprint
+
+bp = Blueprint('main', __name__)
+
+@bp.route('/')
+def index():
+    return "Welcome to OriEx"

--- a/backend/config.py
+++ b/backend/config.py
@@ -1,0 +1,6 @@
+import os
+
+class Config:
+    SECRET_KEY = os.environ.get('SECRET_KEY', 'devkey')
+    SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL', 'postgresql://localhost/oriex')
+    SQLALCHEMY_TRACK_MODIFICATIONS = False

--- a/backend/run.py
+++ b/backend/run.py
@@ -1,0 +1,6 @@
+from app import create_app
+
+app = create_app()
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,3 @@
+# OriEx Frontend
+
+This folder contains the React application.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "oriex-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-scripts": "5.0.1"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test",
+    "eject": "react-scripts eject"
+  }
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>OriEx</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,0 +1,9 @@
+function App() {
+  return (
+    <div>
+      <h1>OriEx Frontend</h1>
+    </div>
+  );
+}
+
+export default App;

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+Flask-SQLAlchemy
+psycopg2-binary


### PR DESCRIPTION
## Summary
- initialize Python Flask backend with basic app and routes
- add React frontend skeleton
- add requirements and gitignore
- update project README

## Testing
- `python -m py_compile backend/app/__init__.py backend/app/routes.py backend/config.py backend/run.py`
