### PR TITLE
Add AGENTS instructions and backend requirements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# Environment Setup
+Python dependencies are listed in `backend/requirements.txt`.
+Install them with:
+
+```bash
+pip install -r backend/requirements.txt
+```
+
+# Testing
+Run Python tests with:
+
+```bash
+pytest -q backend/tests
+```

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,7 @@
+Flask
+SQLAlchemy
+Flask-SQLAlchemy
+psycopg2-binary # Para PostgreSQL
+Flask-Bcrypt
+Flask-JWT-Extended
+pytest


### PR DESCRIPTION
## Summary
- document setup and test commands for Codex agents
- add backend requirements with pytest listed

## Testing
- `pytest -q backend/tests` *(fails: No module named 'psycopg2')*
