### PR TITLE
Add backend setup script and requirements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+Before running tests, execute the setup script:
+
+```
+./codex_setup.sh
+```

--- a/README.md
+++ b/README.md
@@ -9,3 +9,11 @@ Web application for managing shipping services from China to Argentina.
 
 This repository contains a basic project structure with a Flask backend and a React frontend.
 
+
+## Development
+
+Run the setup script before executing tests to ensure dependencies are installed:
+
+```bash
+./codex_setup.sh
+```

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,7 @@
+pytest
+Flask
+SQLAlchemy
+Flask-SQLAlchemy
+psycopg2-binary
+Flask-Bcrypt
+Flask-JWT-Extended

--- a/codex_setup.sh
+++ b/codex_setup.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+pip install -r backend/requirements.txt


### PR DESCRIPTION
## Summary
- specify backend dependencies in `backend/requirements.txt`
- provide setup script `codex_setup.sh` for installing backend packages
- document that the setup script should run before tests
- tell Codex about the setup step via `AGENTS.md`

## Testing
- `./codex_setup.sh` *(fails: Could not find a version that satisfies the requirement pytest)*
- `pytest -q` *(fails: command not found)*
