### PR TITLE
Add Python cache ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+# Ignore Python cache directories and compiled files
 # Python
 __pycache__/
 *.pyc


### PR DESCRIPTION
## Summary
- document ignoring Python cache files in `.gitignore`

## Testing
- `pytest -q` *(fails: `pytest` not found)*