### PR TITLE
Add shipping calculator React component and page

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,8 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-scripts": "5.0.1"
+    "react-scripts": "5.0.1",
+    "react-router-dom": "^6.22.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,8 +1,16 @@
+import React from 'react';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import HomePage from './components/pages/HomePage';
+import ShippingCalculatorPage from './components/pages/ShippingCalculatorPage';
 
 function App() {
   return (
-    <HomePage />
+    <Router>
+      <Routes>
+        <Route path="/" element={<HomePage />} />
+        <Route path="/shipping-calculator" element={<ShippingCalculatorPage />} />
+      </Routes>
+    </Router>
   );
 }
 

--- a/frontend/src/components/pages/HomePage.js
+++ b/frontend/src/components/pages/HomePage.js
@@ -1,4 +1,6 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
+import ShippingCalculator from '../shipping/ShippingCalculator';
 import styles from './HomePage.module.css';
 
 function HomePage() {
@@ -13,9 +15,16 @@ function HomePage() {
           conectar tus compras y negocios.
         </p>
         <div className={styles.heroButtons}>
-          <button className={styles.primaryBtn}>Calcular Envío Ahora</button>
+          <Link className={styles.primaryBtn} to="/shipping-calculator">
+            Calcular Envío Ahora
+          </Link>
           <button className={styles.secondaryBtn}>Rastrear Paquete</button>
         </div>
+      </section>
+
+      <section className={styles.calculatorSection}>
+        <h2>Calcula tu Envío</h2>
+        <ShippingCalculator />
       </section>
 
       <section className={styles.whyUs}>

--- a/frontend/src/components/pages/HomePage.module.css
+++ b/frontend/src/components/pages/HomePage.module.css
@@ -54,3 +54,7 @@
 .footerLinks a {
   margin: 0 0.5rem;
 }
+
+.calculatorSection {
+  margin-bottom: 3rem;
+}

--- a/frontend/src/components/pages/ShippingCalculatorPage.js
+++ b/frontend/src/components/pages/ShippingCalculatorPage.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import ShippingCalculator from '../shipping/ShippingCalculator';
+
+function ShippingCalculatorPage() {
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h1>Calculadora de Envíos</h1>
+      <ShippingCalculator />
+    </div>
+  );
+}
+
+export default ShippingCalculatorPage;

--- a/frontend/src/components/shipping/ShippingCalculator.js
+++ b/frontend/src/components/shipping/ShippingCalculator.js
@@ -1,0 +1,61 @@
+import React, { useState } from 'react';
+import styles from './ShippingCalculator.module.css';
+
+function ShippingCalculator() {
+  const [weight, setWeight] = useState('');
+  const [result, setResult] = useState(null);
+  const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleCalculate = async () => {
+    setLoading(true);
+    setError(null);
+    setResult(null);
+    try {
+      const response = await fetch('/api/calculate_shipping', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ weight_kg: parseFloat(weight) }),
+      });
+      const data = await response.json();
+      if (!response.ok) {
+        setError(data.error || 'Error desconocido');
+      } else {
+        setResult(data);
+      }
+    } catch (err) {
+      setError('Error de red');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.inputGroup}>
+        <label>
+          Peso del Paquete (kg):
+          <input
+            type="number"
+            value={weight}
+            onChange={(e) => setWeight(e.target.value)}
+            min="0"
+            step="0.01"
+          />
+        </label>
+      </div>
+      <button onClick={handleCalculate} disabled={loading}>
+        {loading ? 'Calculando...' : 'Calcular Costo'}
+      </button>
+      {error && <div className={styles.error}>{error}</div>}
+      {result && (
+        <div className={styles.result}>
+          <div>Peso Ingresado: {result.weight_kg} kg</div>
+          <div>Costo Estimado Total (USD): {result.total_client_price_usd}</div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default ShippingCalculator;

--- a/frontend/src/components/shipping/ShippingCalculator.module.css
+++ b/frontend/src/components/shipping/ShippingCalculator.module.css
@@ -1,0 +1,19 @@
+.container {
+  border: 1px solid #ccc;
+  padding: 1rem;
+  max-width: 400px;
+}
+
+.inputGroup {
+  margin-bottom: 1rem;
+}
+
+.error {
+  color: red;
+  margin-top: 0.5rem;
+}
+
+.result {
+  margin-top: 1rem;
+  font-weight: bold;
+}


### PR DESCRIPTION
## Summary
- add `ShippingCalculator` component to call `/api/calculate_shipping`
- display calculator on new `/shipping-calculator` page
- include calculator on home page with link
- enable routing via `react-router-dom`

## Testing
- `pip install -r backend/requirements.txt` *(fails: no network)*
- `pytest -q backend/tests` *(fails: ModuleNotFoundError: No module named 'flask')*